### PR TITLE
Do not add commas when generating multiple Allow/Disallow rules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,14 +23,14 @@ RobotsPlugin.prototype = {
         text += `User-agent: ${userAgent.name}\n`;
 
         if (userAgent.disallow && userAgent.disallow.length > 0) {
-          text += userAgent.disallow.map(disallow => {
-            return `Disallow: ${disallow}\n`;
+          userAgent.disallow.map(disallow => {
+            text += `Disallow: ${disallow}\n`;
           });
         }
 
         if (userAgent.allow && userAgent.allow.length > 0) {
-          text += userAgent.allow.map(allow => {
-            return `Allow: ${allow}\n`;
+          userAgent.allow.map(allow => {
+            text += `Allow: ${allow}\n`;
           });
         }
         return text + '\n';

--- a/test/generate-default.js
+++ b/test/generate-default.js
@@ -42,6 +42,38 @@ Allow: /`;
     });
   });
 
+  it('generates a robots.txt with multiple allows', function(done) {
+
+    const expected = `User-agent: *
+Allow: /
+Allow: /cgi-bin`;
+
+    const webpackConfig = {
+      entry: Path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: Path.join(__dirname, OUTPUT_PATH),
+        filename: 'index.js'
+      },
+      plugins: [new Plugin({
+        userAgents: [{
+          name: '*',
+          allow: ['/', '/cgi-bin']
+        }]
+      })]
+    };
+
+    webpack(webpackConfig, function(error, stats) {
+      expect(error).to.be.null;
+      expect(stats.hasErrors()).to.be.false;
+
+      fs.readFile(Path.join(__dirname, OUTPUT_PATH, 'robots.txt'), {encoding: 'utf8'}, function(fsError, data) {
+        expect(fsError).to.be.null;
+        expect(data).to.equal(expected);
+        done();
+      });
+    });
+  });
+
   it('generates a disallow robots.txt', function(done) {
 
     const expected = `User-agent: *
@@ -57,6 +89,38 @@ Disallow: /`;
         userAgents: [{
           name: '*',
           disallow: ['/']
+        }]
+      })]
+    };
+
+    webpack(webpackConfig, function(error, stats) {
+      expect(error).to.be.null;
+      expect(stats.hasErrors()).to.be.false;
+
+      fs.readFile(Path.join(__dirname, OUTPUT_PATH, 'robots.txt'), {encoding: 'utf8'}, function(fsError, data) {
+        expect(fsError).to.be.null;
+        expect(data).to.equal(expected);
+        done();
+      });
+    });
+  });
+
+  it('generates a robots.txt with multiple disallows', function(done) {
+
+    const expected = `User-agent: *
+Disallow: /
+Disallow: /cgi-bin`;
+
+    const webpackConfig = {
+      entry: Path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: Path.join(__dirname, OUTPUT_PATH),
+        filename: 'index.js'
+      },
+      plugins: [new Plugin({
+        userAgents: [{
+          name: '*',
+          disallow: ['/', '/cgi-bin']
         }]
       })]
     };


### PR DESCRIPTION
Fix a bug to remove unwanted commas from the output when having multiple Allow and/or Disallow for the same agent. 

Using the string `+=` operator to add the Array.map output to a string results in unwanted commas added to the string.

Added unit tests too to cover this edge cvase
