### PR TITLE
Added support for custom filename

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,8 @@ function RobotsPlugin(options) {
       name: '*',
       allow: ['/'],
       disallow: []
-    }]
+    }],
+    filename: 'robots.txt',
   }, options);
 }
 
@@ -40,7 +41,7 @@ RobotsPlugin.prototype = {
       }
       const stringifiedOutput = output.join('').trim();
 
-      compilation.assets['robots.txt'] = {
+      compilation.assets[this.options.filename] = {
         source: function() {
           return stringifiedOutput
         },


### PR DESCRIPTION
You can now specify the output filename. Useful if you need to put the robots.txt inside a different folder.
